### PR TITLE
Also check for Java libs in new Java 9 directory structure

### DIFF
--- a/ac/ac_jni_include_dirs.m4
+++ b/ac/ac_jni_include_dirs.m4
@@ -122,6 +122,8 @@ if test -z "$JNI_CLIENT_DIRS"; then
 		echo "Trying $_JTOPDIR/jre/$d/$subd"
 		if test -d $_JTOPDIR/jre/$d/$subd; then
 			JNI_CLIENT_DIRS="$JNI_CLIENT_DIRS $_JTOPDIR/jre/$d/$subd $_JTOPDIR/jre/$d"
+		elif test -d $_JTOPDIR/$d/$subd; then
+			JNI_CLIENT_DIRS="$JNI_CLIENT_DIRS $_JTOPDIR/$d/$subd $_JTOPDIR/$d"
 		fi
 	done
   done


### PR DESCRIPTION
Prior to Java 9, the macOS version of Java placed the `libjvm.dylib` file at `$JAVA_HOME/jre/lib/server`. As of Java 9, it now lives at `$JAVA_HOME/lib/server`. This breaks the JPL build under Java 9, as it's looking for the `libjvm.dylib` file in the wrong place. (For details on why they moved it, see [JEP 220](http://openjdk.java.net/jeps/220).)

This may also move it on other OSes, as `$JAVA_HOME/lib/server` should now be the "standard" location for the `libjvm` library on macOS, Solaris, and Linux. However I have not checked that this is the case.