### PR TITLE
fix openjdk9 directory check for linux

### DIFF
--- a/ac/ac_jni_include_dirs.m4
+++ b/ac/ac_jni_include_dirs.m4
@@ -113,6 +113,8 @@ darwin*)	_JNI_LIBDIRS="lib"
 		_JNI_LIBDIRS="lib/$host_cpu"
 		_JNI_LIBSUBDIRS="server"
   esac
+  # also check directly under lib without architecture directory for jdk9
+  _JNI_LIBDIRS="$_JNI_LIBDIRS lib"
 ;;
 esac
 


### PR DESCRIPTION
Followup to #6, see [1] for a build failure with openjdk9 on debian.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=893421