### PR TITLE
Add Rationals as a type

### DIFF
--- a/docs/JavaApiOverview.md
+++ b/docs/JavaApiOverview.md
@@ -191,6 +191,30 @@ To obtain the *ith* argument of a compound (numbered from 0), use the **arg0()**
 public Term arg0(int i);
 ```
 
+#### Lists as compound terms
+
+Lists are, as usual in Prolog, just compound terms with function `[|]` and two arguments: the _head_ element and the _tail_ list. For example:
+
+```prolog
+?- A = [1,2,3,4], A =.. [X|Y].
+A = [1, 2, 3, 4],
+X = '[|]',
+Y = [1, [2, 3, 4]].
+````
+
+We can build list compound terms in two ways. First, by using `Util.termArrayToList`:
+
+```java
+Term list = Util.termArrayToList(new Term[] 
+        { new Integer(1), new Variable("B"), new Atom("c") });
+```        
+
+The second way is by just using a String:
+
+
+
+
+
 ## Creating queries
 
 A `Query` contains a `Term`, representing a Prolog goal:

--- a/docs/JavaApiOverview.md
+++ b/docs/JavaApiOverview.md
@@ -21,6 +21,7 @@ org.jpl7
  |    +-- Compound
  |    +-- Float
  |    +-- Integer
+ |    +-- Rational
  |    +-- Variable
  |    +-- JRef
  +-- Util
@@ -95,7 +96,7 @@ An atom's name is retrieved with its `name()` method, e.g.
 a1.name()
 ```
 
-See [org.jpl7.Atom JavaDoc](http://192.168.1.49:8080/jpl7/doc/org/jpl7/Atom.html) for details of how SWI Prolog version 7's strings and blobs (including reserved symbols) are accommodated.
+See [org.jpl7.Atom JavaDoc](https://jpl7.org/javadoc/org/jpl7/Atom.html) for details of how SWI Prolog version 7's strings and blobs (including reserved symbols) are accommodated.
 
 ### Variables
 
@@ -113,7 +114,7 @@ They are just tokens, and do not behave like Prolog variables.
 
 ### Integers
 
-A `org.jpl7.Integer` is a specialized `org.jpl7.Term` which holds a Java long value or a `java.math.BigInteger` object. This class corresponds to the Prolog *integer* type.
+A `org.jpl7.Integer` is a specialized `org.jpl7.Term` which holds a Java long value or a `java.math.BigInteger` object. This class corresponds to the Prolog *integer* [arithmethic type](https://www.swi-prolog.org/pldoc/man?section=artypes).
 
 ```java
 org.jpl7.Integer i = new org.jpl7.Integer(5);
@@ -125,9 +126,27 @@ The `org.jpl7.Integer` class has an `intValue()` accessor to obtain the `int` va
 
 If `isBig()` returns true, then the value is outside the range of a Java `long`, and is retrieved by `bigValue()`.
 
+### Rational
+
+A `org.jpl7.Rational` is a specialized `org.jpl7.Term` which holds two Java long values for numerator and denominator. This class corresponds to the Prolog [*rational* arithmetic type](https://www.swi-prolog.org/pldoc/man?section=rational).
+
+```java
+org.jpl7.Integer i = new org.jpl7.Rational(5, 2);
+```
+
+or from a String with the `<number>r<number` format:
+
+```java
+org.jpl7.Integer i = new org.jpl7.Rational("5r2");
+```
+
+The `org.jpl7.Rational` class has an `floatValue()` and `doubleValue()` methods, as well as `intValue()` that will perform Integer division (thus dropping the decimal part). It also provides getters ``getNumerator()`` and ``getDenominator()``.
+
+
+
 ### Floats
 
-A `org.jpl7.Float` is a specialized `org.jpl7.Term` which holds a Java `double` value. This class corresponds to the Prolog *float* type (64-bit ISO/IEC in SWI Prolog).
+A `org.jpl7.Float` is a specialized `org.jpl7.Term` which holds a Java `double` value. This class corresponds to the Prolog *float* [arithmethic type](https://www.swi-prolog.org/pldoc/man?section=artypes) (64-bit ISO/IEC in SWI Prolog).
 
 ```java
 org.jpl7.Float f = new org.jpl7.Float(3.14159265);

--- a/docs/JavaApiOverview.md
+++ b/docs/JavaApiOverview.md
@@ -193,7 +193,7 @@ public Term arg0(int i);
 
 #### Lists as compound terms
 
-Lists are, as usual in Prolog, just compound terms with function `[|]` and two arguments: the _head_ element and the _tail_ list. For example:
+As usual in Prolog, lists are just compound terms with function `[|]` and two arguments: the _head_ element and the _tail_ list. For example:
 
 ```prolog
 ?- A = [1,2,3,4], A =.. [X|Y].
@@ -202,14 +202,18 @@ X = '[|]',
 Y = [1, [2, 3, 4]].
 ````
 
-We can build list compound terms in two ways. First, by using `Util.termArrayToList`:
+We can build list compound terms in two ways. First, by converting an Array of terms (`Term[]`) into a Compound (list) term using utility `Util.termArrayToList`:
 
 ```java
 Term list = Util.termArrayToList(new Term[] 
         { new Integer(1), new Variable("B"), new Atom("c") });
 ```        
 
-The second way is by just using a String:
+The second way is by converting a String representing a list into a term via `Util.textToTerm`:
+
+```java
+Term list = Util.textToTerm("[1, B, c]");
+```
 
 
 

--- a/src/c/jpl.c
+++ b/src/c/jpl.c
@@ -136,6 +136,7 @@ refactoring (trivial):
 #define JNI_XPUT_ATOM 13
 #define JNI_XPUT_JVALUEP 14
 #define JNI_XPUT_JVALUE 15
+#define JNI_XPUT_RATIONAL 15
 
 /* JNI "hashed refs" constants */
 
@@ -3891,6 +3892,29 @@ Java_org_jpl7_fli_Prolog_get_1integer_1big(
 
 /*
  * Class:     org_jpl7_fli_Prolog
+ * Method:    get_rational
+ * Signature: (Lorg/jpl7/fli/term_t;Lorg/jpl7/fli/StringHolder;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_org_jpl7_fli_Prolog_get_1rational(
+        JNIEnv *env, jclass jProlog, jobject jterm,
+        jobject jrational_holder /* we trust this is a StringHolder */
+)
+{ term_t  term;
+    char *  rational;
+    jstring jrational;
+
+    return (jpl_ensure_pvm_init(env) &&
+            jrational_holder != NULL &&
+            getTermValue(env, jterm, &term) &&
+            PL_get_chars(term, &rational, CVT_RATIONAL) &&
+            (jrational = (*env)->NewStringUTF(env, rational)) &&
+            setStringValue(env, jrational_holder, jrational) );
+}
+
+
+/*
+ * Class:     org_jpl7_fli_Prolog
  * Method:    get_name_arity
  * Signature: (Lorg/jpl7/fli/term_t;Lorg/jpl7/fli/StringHolder;Lorg/jpl7/fli/IntHolder;)Z
  */
@@ -4227,6 +4251,26 @@ Java_org_jpl7_fli_Prolog_put_1integer_1big(JNIEnv *env, jclass jProlog,
   { return FALSE;
   }
 }
+
+/*
+ * Class:     org_jpl7_fli_Prolog
+ * Method:    put_rational
+ * Signature: (Lorg/jpl7/fli/term_t;Ljava/lang/String;)V
+ */
+JNIEXPORT jboolean JNICALL
+Java_org_jpl7_fli_Prolog_put_1rational(JNIEnv *env, jclass jProlog,
+                                           jobject jterm, jstring jvalue)
+{ term_t term;
+
+  if ( jpl_ensure_pvm_init(env) &&
+       getTermValue(env, jterm, &term))
+  { return PL_chars_to_term((char *)(*env)->GetStringUTFChars(env, jvalue, 0),
+                            term);
+  } else
+  { return FALSE;
+  }
+}
+
 
 /*
  * Class:     org_jpl7_fli_Prolog

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CLS	org/jpl7/Atom.java
 	org/jpl7/Compound.java
 	org/jpl7/Float.java
 	org/jpl7/Integer.java
+	org/jpl7/Rational.java
 	org/jpl7/JRef.java
 	org/jpl7/JPLException.java
 	org/jpl7/JPL.java
@@ -52,6 +53,7 @@ set(TEST
     org/jpl7/test/junit/Tests.java
     org/jpl7/test/junit/GetSolution.java
     org/jpl7/test/junit/QueryBuilder.java
+    org/jpl7/test/junit/RationalTest.java
     org/jpl7/test/junit/Variables.java
     org/jpl7/test/junit/MutualRecursion.java
     org/jpl7/test/junit/AtomTest.java

--- a/src/java/org/jpl7/Rational.java
+++ b/src/java/org/jpl7/Rational.java
@@ -4,6 +4,7 @@ import org.jpl7.fli.Prolog;
 import org.jpl7.fli.term_t;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Integer is a specialised Term representing a Prolog integer value; if the value fits, it is held in a long field,
@@ -62,7 +63,7 @@ public class Rational extends Term {
 	 */
 	public Rational(long numerator, long denominator) {
 		if (denominator == 0) {
-			throw new JPLException("cannot represent value as a long");
+			throw new JPLException("denominator of rational cannot be 0");
 		} else {
 			// reduce fraction
 			long g = gcd(numerator, denominator);
@@ -90,8 +91,32 @@ public class Rational extends Term {
 	 *            The rational numbre in format NrM
 	 */
 	public Rational(String rat) {
-		this(Long.parseLong(rat.split("r", -2)[0]),
-				Long.parseLong(rat.split("r", -2)[1]));
+		if (Pattern.compile("-?\\d+r\\d+").matcher(rat).matches()) {
+			long numerator = Long.parseLong(rat.split("r", -2)[0]);
+			long denominator = Long.parseLong(rat.split("r", -2)[1]);
+
+			if (denominator == 0) {
+				throw new JPLException("denominator of rational cannot be 0");
+			} else {
+				// reduce fraction
+				long g = gcd(numerator, denominator);
+
+				long num = numerator / g;
+				long dem = denominator / g;
+
+				// needed only for negative numbers
+				if (dem < 0) {
+					this.denominator = -dem;
+					this.numerator = -num;
+				} else {
+					this.denominator = dem;
+					this.numerator = num;
+				}
+			}
+			this.rat = String.format("%sr%s", numerator, denominator);
+		} else {
+			throw new JPLException("incorrect format for rational number; should be of the form NrM.");
+		}
 	}
 
 	// return gcd(|m|, |n|)

--- a/src/java/org/jpl7/Rational.java
+++ b/src/java/org/jpl7/Rational.java
@@ -1,0 +1,227 @@
+package org.jpl7;
+
+import org.jpl7.fli.Prolog;
+import org.jpl7.fli.term_t;
+
+import java.util.Map;
+
+/**
+ * Integer is a specialised Term representing a Prolog integer value; if the value fits, it is held in a long field,
+ * else as a BigInteger.
+ *
+ * <pre>
+ * Integer i = new Integer(1024);
+ * </pre>
+ *
+ * Once constructed, the value of an Integer instance cannot be altered. An Integer can be used (and re-used) as an
+ * argument of Compounds. Beware confusing jpl.Integer with java.lang.Integer.
+ *
+ * <hr>
+ * Copyright (C) 2004 Paul Singleton
+ * <p>
+ * Copyright (C) 1998 Fred Dushin
+ * <p>
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * <ol>
+ * <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ * </ol>
+ *
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * <hr>
+ *
+ * @see Term
+ * @see Compound
+ */
+public class Rational extends Term {
+
+	/**
+	 * the Integer's immutable long value, iff small enough
+	 */
+	protected final long numerator;
+	protected final long denominator;
+	protected final String rat;
+
+
+
+	/**
+	 * @param numerator
+	 *            This Integer's intended (long) value
+	 */
+	public Rational(long numerator, long denominator) {
+		if (denominator == 0) {
+			throw new JPLException("cannot represent value as a long");
+		} else {
+			// reduce fraction
+			long g = gcd(numerator, denominator);
+
+			long num = numerator / g;
+			long dem = denominator / g;
+
+			// needed only for negative numbers
+			if (dem < 0) {
+				this.denominator = -dem;
+				this.numerator = -num;
+			} else {
+				this.denominator = dem;
+				this.numerator = num;
+			}
+		}
+		if (denominator == 1) {
+			throw new JPLException("the denominator is 1 so it should be an Integer.");
+		} else
+			this.rat = String.format("%sr%s", numerator, denominator);
+	}
+
+	/**
+	 * @param rat
+	 *            The rational numbre in format NrM
+	 */
+	public Rational(String rat) {
+		this(Long.parseLong(rat.split("r", -2)[0]),
+				Long.parseLong(rat.split("r", -2)[1]));
+	}
+
+	// return gcd(|m|, |n|)
+	private static long gcd(long m, long n) {
+		if (m < 0) m = -m;
+		if (n < 0) n = -n;
+		if (0 == n) return m;
+		else return gcd(n, m % n);
+	}
+
+	public Term[] args() {
+		return new Term[] {};
+	}
+
+	/**
+	 * two Integer instances are equal if their values are equal
+	 *
+	 * @param obj
+	 *            The Object to compare (not necessarily an Integer)
+	 * @return true if the Object satisfies the above condition
+	 */
+	public final boolean equals(Object obj) {
+		if (this == obj) { // the very same Integer
+			return true; // necessarily equal
+		} else if (obj instanceof Rational) {
+			Rational that = (Rational) obj;
+			if (this.numerator == that.numerator && this.denominator == that.denominator) {
+				return true;
+			} else
+				return false;
+		} else {
+			return false;
+		}
+	}
+
+	public final long getNumerator() {
+		return numerator;
+	};
+	public final long getDenominator() {
+		return denominator;
+	};
+
+	/**
+	 * whether this Rational's functor has (long) 'name' and 'arity' (c.f. traditional functor/3)
+	 *
+	 * @return whether this Rational's functor has (long) 'name' and 'arity'
+	 */
+	public final boolean hasFunctor(long val, int arity) {
+		return this.numerator == val &&  arity == 0;
+	}
+
+
+	/**
+	 * Returns the value of this Rational as an int if possible, else throws a JPLException
+	 *
+	 * @throws JPLException
+	 *             if the value of this Rational is too great to be represented as a Java int
+	 * @return the int value of this Rational
+	 */
+	public final int intValue() {
+		return (int) Math.round(numerator / denominator);
+	}
+
+		/**
+	 * Returns the value of this org.jpl7.Rational as a long
+	 *
+	 * @return the value of this org.jpl7.Rational as a long
+	 */
+	public final long longValue() {
+			return (long) numerator / denominator;
+	}
+
+	/**
+	 * Returns the value of this Rational converted to a float
+	 *
+	 * @return the value of this Rational converted to a float
+	 */
+	public final float floatValue() {
+		return numerator / (float) denominator;
+	}
+
+	/**
+	 * Returns the value of this Rational converted to a double
+	 *
+	 * @return the value of this Rational converted to a double
+	 */
+	public final double doubleValue() {
+		return numerator / (double) denominator;
+	}
+
+
+
+
+	/**
+	 * To convert an Rational into a Prolog term, we put its value into the term_t.
+	 *
+	 * @param varnames_to_vars
+	 *            A Map from variable names to Prolog variables.
+	 * @param term
+	 *            A (previously created) term_t which is to be set to a Prolog integer
+	 */
+	protected final void put(Map<String, term_t> varnames_to_vars, term_t term) {
+		Prolog.put_rational(term, this.toString());
+	}
+
+	/**
+	 * a Prolog source text representation of this Rational's value
+	 *
+	 * @return a Prolog source text representation of this Rational's value
+	 */
+	public String toString() {
+		return String.format("%sr%s", numerator, denominator);
+	}
+
+	/**
+	 * the type of this term, as "Prolog.INTEGER"
+	 *
+	 * @return the type of this term, as "Prolog.INTEGER"
+	 */
+	public final int type() {
+		return Prolog.RATIONAL;
+	}
+
+	/**
+	 * the name of the type of this term, as "Rational"
+	 *
+	 * @return the name of the type of this term, as "Rational"
+	 */
+	public String typeName() {
+		return "Rational";
+	}
+
+}

--- a/src/java/org/jpl7/Term.java
+++ b/src/java/org/jpl7/Term.java
@@ -139,7 +139,8 @@ public abstract class Term {
 	}
 
 	/**
-	 * This method computes a substitution from a Term. The bindings Map stores Terms, keyed by names of Variables.
+	 * This method computes a substitution from a Term (the current object).
+	 * The bindings Map varnames_to_Terms maps names of Variables to Terms.
 	 * Thus, a substitution is as it is in mathematical logic, a sequence of the form \sigma = {t_0/x_0, ..., t_n/x_n}.
 	 * Once the substitution is computed, the substitution should satisfy
 	 *
@@ -149,8 +150,8 @@ public abstract class Term {
 	 * query.
 	 * <p>
 	 *
-	 * A second Map, vars, is required; this table holds the Variables that occur (thus far) in the unified term. The
-	 * Variable instances in this table are guaranteed to be unique and are keyed on Strings which are Prolog internal
+	 * A second Map, vars_to_Vars, is required: this table holds the Variables that occur (thus far) in the unified term.
+	 * 	The Variable instances in this table are guaranteed to be unique and are keyed on Strings which are Prolog internal
 	 * representations of the variables.
 	 *
 	 * @param varnames_to_Terms
@@ -237,7 +238,15 @@ public abstract class Term {
 					return new org.jpl7.Integer(-3); // arbitrary
 				}
 			}
-		case Prolog.FLOAT: // 4
+		case Prolog.RATIONAL: // 4
+			hString = new StringHolder();
+			if (Prolog.get_rational(term, hString)) {
+				// System.out.println("bigint = " + hString.value);
+				return new org.jpl7.Rational(hString.value);
+			} else {
+				return new org.jpl7.Integer(-3); // arbitrary
+			}
+		case Prolog.FLOAT: // 5
 			DoubleHolder hFloatValue = new DoubleHolder();
 			Prolog.get_float(term, hFloatValue); // assume it succeeds...
 			return new org.jpl7.Float(hFloatValue.value);
@@ -550,6 +559,9 @@ public abstract class Term {
 		throw new JPLException("name() is undefined for " + this.typeName());
 	}
 
+	public void setName(String name) {
+		throw new JPLException("name() is undefined for " + this.typeName());
+	}
 	/**
 	 * The Object which this org.jpl7.JRef refers to, iff this Term is a JRef or just JPL.JNULL.
 	 *

--- a/src/java/org/jpl7/Util.java
+++ b/src/java/org/jpl7/Util.java
@@ -121,17 +121,62 @@ public final class Util {
 	 * @throws PrologException containing error(syntax_error(_),_) if text is invalid as a term.
 	 */
 	public static Term textToTerm(String text) {
+
+		/**
+		 *  atom_to_term/3 will build a term from a string, and will extract all variables in a list
+		 *  https://www.swi-prolog.org/pldoc/doc_for?object=atom_to_term/3
+		 *
+		 * ?- atom_to_term('mother(maria, S, P)', X, Y).
+		 * 				X = mother(maria, _4518, _4520),
+		 * 				Y = ['S'=_4518, 'P'=_4520].
+		 *
+		 * 	But we want to return the Term mother(maria, S, P) where S and P are Variable Terms referring
+		 * 	to _4518 and _4520
+		 */
+
 		// it might be better to use PL_chars_to_term()
 		Query q = new Query(new Compound("atom_to_term",
-				new Term[] { new Atom(text), new Variable("Term"), new Variable("NVdict") }));
+				new Term[] { new Atom(text), new Variable("T"), new Variable("NVdict") }));
 		q.open();
-		Map<String, Term> s = q.getSubstWithNameVars();
-		if (s != null) {
+
+		// quer is open, check if there is a solution
+		if (q.hasMoreSolutions()) {
+			// cannot use  this bc it gives anonymous vars, we lose the names
+			// If we use this we will get T mmapped to Term mother(maria, _1, _2) but we want mother(maria, X, Y)
+			Map<String, Term> s = q.nextSolution();
+
+			// New way of doing it (April 2020)
+			//		The term bounded to variable T above has the atom query as a proper Term but
+			//			the variables mentioned have anonymous names _1 and _2, instead of X and Y
+			//		However, the mapping between those _ variables and the actual textual names X and Y have been
+			//			bound in variable NVdict as a list of 'X' = _1, 'X' = _2, etc...
+			//		So, we navigate NVdict and we change the name of each Variable _ to be its textual name!
+			//		Since the Term bound to T will use exactl the Variables _1, _2, etc, by changing their names
+			//			the term T will now use Variables X, Y, etc as wanted!
+			//Term T = s.get("T");
+			Term[] VarsMapList = Util.listToTermArray(s.get("NVdict"));	// this is a Compound list of mappings
+			for (Term map : VarsMapList) { // map represents 'X' = _1
+				String VarName = map.arg(1).name();		// extract the symbolic name
+				Variable Var = (Variable) map.arg(2);					// extract Variable object
+				Var.setName(VarName);
+			}
+
+			// Old way of doing it (before April 2020) - extremely involved!
+			//Map<String, Term> s = q.getSolutionWithVarNames();
+
 			q.close();
-			return (Term) s.get("Term");
+			return (Term) s.get("T");
 		} else {
 			return null;
 		}
+
+//		Map<String, Term> s = q.getSubstWithNameVars();
+//		if (s != null) {
+//			q.close();
+//			return (Term) s.get("Term");
+//		} else {
+//			return null;
+//		}
 	}
 
 	/**

--- a/src/java/org/jpl7/Variable.java
+++ b/src/java/org/jpl7/Variable.java
@@ -58,9 +58,9 @@ public class Variable extends Term {
 	protected transient int index; // only used by (redundant?)
 
 	/**
-	 * the name of this Variable
+	 * the name of this Variable (may be changed)
 	 */
-	public final String name;
+	public  String name;
 
 	/**
 	 * defined between Query.open() and Query.get2()
@@ -118,11 +118,20 @@ public class Variable extends Term {
 	}
 
 	/**
-	 * If this Variable instance is not an anonymous or (in dont-tell-me mode) a
-	 * dont-tell-me variable, and its binding is not already in the
-	 * varnames_to_Terms Map, put the result of converting the term_t to which
-	 * this variable has been unified to a Term in the Map, keyed on this
-	 * Variable's name.
+	 * This can be used to get the current solution binding of the Variable instance.
+	 * So we are calling when the goal is in a solution
+	 *
+	 * This mtehod returns nothing but modifies the argument mappings, by filling
+	 * them with the current solution binding of the Variable instance.
+	 *
+	 * If Variable instance is anonymous or a dont-tell-me variable, then do nothing
+	 *
+	 * Otherwise, if the Variable instance is not already in the varnames_to_Terms Map,
+	 * put the result of converting the term_t to which this variable has been unified
+	 * (in the current solution) to a Term in the Map, keyed on this Variable's name.
+	 *
+	 * In binding the Variable instance to the Term (in the current solution), such Term
+	 * may also refer to free variables, whose maps are stores in vars_to_Vars
 	 *
 	 * @param varnames_to_Terms
 	 *            A Map of bindings from variable names to JPL Terms.
@@ -174,6 +183,11 @@ public class Variable extends Term {
 	public final String name() {
 		return this.name;
 	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
 
 	/**
 	 * To put a Variable, we must check whether a (non-anonymous) variable with

--- a/src/java/org/jpl7/fli/Prolog.java
+++ b/src/java/org/jpl7/fli/Prolog.java
@@ -74,7 +74,7 @@ public final class Prolog {
 	public static final int VARIABLE = 1; // PL_VARIABLE
 	public static final int ATOM = 2; // PL_ATOM
 	public static final int INTEGER = 3; // PL_INTEGER
-	public static final int RATIONAL = 4; // PL_INTEGER
+	public static final int RATIONAL = 4; // PL_RATIONAL
 	public static final int FLOAT = 5; // PL_FLOAT
 	public static final int STRING = 6; // PL_STRING
 	public static final int COMPOUND = 7; // PL_TERM
@@ -106,7 +106,7 @@ public final class Prolog {
 	public static final int CVT_RATIONAL = 0x0010;
 	public static final int CVT_FLOAT = 0x0020;
 	public static final int CVT_VARIABLE = 0x0040;
-	public static final int CVT_NUMBER = (CVT_INTEGER | CVT_FLOAT);
+	public static final int CVT_NUMBER = (CVT_INTEGER | CVT_FLOAT | CVT_RATIONAL);
 	public static final int CVT_ATOMIC = (CVT_NUMBER | CVT_ATOM | CVT_STRING);
 	public static final int CVT_ALL = 0x00ff;
 	public static final int BUF_DISCARDABLE = 0x0000;
@@ -147,6 +147,8 @@ public final class Prolog {
 
 	public static native boolean get_integer_big(term_t t, StringHolder s);
 
+	public static native boolean get_rational(term_t t, StringHolder s);
+
 	public static native boolean get_float(term_t t, DoubleHolder d);
 
 	public static native boolean get_name_arity(term_t t, StringHolder name, IntHolder arity);
@@ -170,6 +172,8 @@ public final class Prolog {
 	public static native void put_integer(term_t t, long i);
 
 	public static native void put_integer_big(term_t t, String i);
+
+	public static native void put_rational(term_t t, String r);
 
 	public static native void put_float(term_t t, double f);
 

--- a/src/java/org/jpl7/test/JPLTestSuite.java
+++ b/src/java/org/jpl7/test/JPLTestSuite.java
@@ -14,16 +14,17 @@ import org.junit.runners.Suite;
         org.jpl7.test.junit.GetSolution.class,
         org.jpl7.test.junit.IntegerTest.class,
         org.jpl7.test.junit.ListTest.class,
-        org.jpl7.test.junit.JRef.class,   // yields error when loading files.so modules
-        org.jpl7.test.junit.ModuleTest.class, // yields error when loading files.so modules
-        org.jpl7.test.junit.MutualRecursion.class,    // yields error when loading files.so modules
+        org.jpl7.test.junit.JRef.class,
+        org.jpl7.test.junit.ModuleTest.class,
+        org.jpl7.test.junit.MutualRecursion.class,
         org.jpl7.test.junit.QueryBuilder.class,
+        org.jpl7.test.junit.RationalTest.class,
         org.jpl7.test.junit.ReportPrologInfo.class,
         org.jpl7.test.junit.StringTest.class,
         org.jpl7.test.junit.TypesTest.class,
         org.jpl7.test.junit.Unicode.class,
         org.jpl7.test.junit.Variables.class,
-        org.jpl7.test.junit.Tests.class,    // yields error when loading files.so modules
+        org.jpl7.test.junit.Tests.class,  
 })
 
 public class JPLTestSuite {

--- a/src/java/org/jpl7/test/junit/RationalTest.java
+++ b/src/java/org/jpl7/test/junit/RationalTest.java
@@ -111,9 +111,7 @@ public class RationalTest extends JPLTest {
 
 
     @Test
-    public void rational_from_Prolog() {
-        final int[] expectedSolutions = {1, 2, 3, 4, 5};
-
+    public void rational_from_String_simple() {
         Rational rat = new Rational("1r4");
 
         Query q = new Query("X is ?", rat);
@@ -122,9 +120,8 @@ public class RationalTest extends JPLTest {
     }
 
 
-
     @Test
-    public void rational_from_Prolog_reduced() {
+    public void rational_from_String_reduced() {
         final int[] expectedSolutions = {1, 2, 3, 4, 5};
 
         Rational rat = new Rational("2r8");
@@ -132,6 +129,44 @@ public class RationalTest extends JPLTest {
         Query q = new Query("X is ?", rat);
         Map<String, Term> s = q.nextSolution();
         assertEquals("1r4", s.get("X").toString());
+    }
+
+    @Test
+    public void rational_from_String_wrong_format1() {
+        final String[] wrongRationals = {"121", "22r", "r33", "ss", "-12r", "r-21"};
+        final String expectedError = "incorrect format for rational number";
+
+        for (String r : wrongRationals) {
+            try {
+                Rational rat = new Rational(r);
+            } catch (JPLException e) {
+                if (e.getMessage().contains(expectedError)) {
+                    // OK: an appropriate exception was thrown
+                } else {
+                    String msg = String.format("did not catch expected error '%s', received: %s ", expectedError, e.toString());
+                    fail(msg);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void rational_from_String_wrong_format2() {
+        final String[] wrongRationals = {"23r0", "-22r0"};
+        final String expectedError = "denominator of rational cannot be 0";
+
+        for (String r : wrongRationals) {
+            try {
+                Rational rat = new Rational(r);
+            } catch (JPLException e) {
+                if (e.getMessage().contains("denominator of rational cannot be 0")) {
+                    // OK: an appropriate exception was thrown
+                } else {
+                    String msg = String.format("did not catch expected error '%s', received: %s ", expectedError, e.toString());
+                    fail(msg);
+                }
+            }
+        }
     }
 
 
@@ -146,5 +181,8 @@ public class RationalTest extends JPLTest {
         Map<String, Term> s = q.nextSolution();
         assertEquals("3r8", s.get("X").toString());
     }
+
+
+
 
 }

--- a/src/java/org/jpl7/test/junit/RationalTest.java
+++ b/src/java/org/jpl7/test/junit/RationalTest.java
@@ -1,0 +1,150 @@
+package org.jpl7.test.junit;
+
+import org.jpl7.*;
+
+import org.jpl7.fli.Prolog;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class RationalTest extends JPLTest {
+
+    public static void main(String argv[]) {
+        // To be able to call it from CLI without IDE (e.g., by CMAKE)
+        org.junit.runner.JUnitCore.main("org.jpl7.test.junit.RationalTest");
+
+        // should work from static class but gives error
+//        org.junit.runner.JUnitCore.main( GetSolution.class.getName()); // full name with package
+    }
+
+    /**
+     * This is done at the class loading, before any test is run
+     */
+    @BeforeClass
+    public static void setUp() {
+        setUpClass();
+    }
+
+
+    @Rule
+    public TestRule watcher = new TestWatcher() {
+        protected void starting(Description description) {
+            reportTest(description);
+        }
+    };
+
+
+
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // SUPPORTING CODE
+    ///////////////////////////////////////////////////////////////////////////////
+
+
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // TESTS
+    ///////////////////////////////////////////////////////////////////////////////
+
+
+
+    @Test
+    public void rational_simple() {
+        Query q = new Query("X = 12r5");
+        Map<String, Term> s = q.nextSolution();
+
+        assertEquals( "12r5", s.get("X").toString());
+        assertEquals("Rational", s.get("X").typeName());
+    }
+
+    @Test
+    public void rational_reduced() {
+        Query q = new Query("X = 2r4");
+        Map<String, Term> s = q.nextSolution();
+
+        assertEquals("1r2", s.get("X").toString());
+    }
+
+
+    @Test
+    public void rational_is_simple() {
+        final int[] expectedSolutions = {1, 2, 3, 4, 5};
+
+//        Rational rat = new Rational("X = 1r4");
+//        System.out.println(rat.toString());
+
+        Query q = new Query("X is 2r4 + 1r3");
+        Map<String, Term> s = q.nextSolution();
+        assertEquals("5r6", s.get("X").toString());
+    }
+
+    @Test
+    public void rational_is_simple2() {
+        Query q = new Query("X is 1r2 + 1r4");
+        Map<String, Term> s = q.nextSolution();
+        assertEquals("3r4", s.get("X").toString());
+    }
+
+    @Test
+    public void rational_is_big() {
+        Query q = new Query("X is 123r13 + 123r8");
+        Map<String, Term> s = q.nextSolution();
+        assertEquals("2583r104", s.get("X").toString());
+    }
+
+
+    @Test
+    public void rational_is_reduced_to_int() {
+        Query q = new Query("X is 1r2 + 1r2");
+        Map<String, Term> s = q.nextSolution();
+        assertEquals(1, s.get("X").intValue());
+        assertEquals("Integer", s.get("X").typeName());
+
+    }
+
+
+    @Test
+    public void rational_from_Prolog() {
+        final int[] expectedSolutions = {1, 2, 3, 4, 5};
+
+        Rational rat = new Rational("1r4");
+
+        Query q = new Query("X is ?", rat);
+        Map<String, Term> s = q.nextSolution();
+        assertEquals("1r4", s.get("X").toString());
+    }
+
+
+
+    @Test
+    public void rational_from_Prolog_reduced() {
+        final int[] expectedSolutions = {1, 2, 3, 4, 5};
+
+        Rational rat = new Rational("2r8");
+
+        Query q = new Query("X is ?", rat);
+        Map<String, Term> s = q.nextSolution();
+        assertEquals("1r4", s.get("X").toString());
+    }
+
+
+    @Test
+    public void rational_from_Prolog_multiply() {
+        final int[] expectedSolutions = {1, 2, 3, 4, 5};
+
+        Rational rat1 = new Rational("2r8");
+        Rational rat2 = new Rational("3r2");
+
+        Query q = new Query("X is ? * ?", new Term[] {rat1, rat2});
+        Map<String, Term> s = q.nextSolution();
+        assertEquals("3r8", s.get("X").toString());
+    }
+
+}


### PR DESCRIPTION
- Added [rationals type](https://www.swi-prolog.org/pldoc/man?section=rational) to JPL
- Involves extension of Java and C code
- Simplified and improved `Util.textToTerm()`
- Updated doc to list `Rational` type.

Fixes #39 