### PR TITLE
Added dictionary support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ packages-jpl.iml
 *.iml
 /out
 SWIJPL-development.md
+examples/java/Scratch.java

--- a/docs/JavaApiOverview.md
+++ b/docs/JavaApiOverview.md
@@ -355,6 +355,33 @@ When it comes to non-empty, compound, list terms, the behavior of `toString()` w
 * If True, lists will be represented as String in the usual Prolog textual representation `[e1, e2, e3, ...., en]`. Note a space wil be added after each comma always.
 * If False, lists will be represented in infix notation with the list pair functor `[|]`, e.g.,  `[|](1, [|](2, [|](3, '[]')))` for list `[1, 2, 3]`.
 
+### Dictionaries
+
+A `org.jpl7.Dict` is a specialized `org.jpl7.Term` encoding a structure with named arguments, that is, dictionaries. A `Dict` has a tag name as a `Term` and a Java `Map` from `Atom` to `Term`. Its String representation is of the form `Tag{Key1:Value1, ...,Keyn:Valuen}`. 
+
+ 
+```java
+Map<Atom, Term> map = new HashMap<Atom, Term>();
+
+map.put(new Atom("x"), new org.jpl7.Integer(12));
+map.put(new Atom("y"), new org.jpl7.Integer(23));
+map.put(new Atom("z"), new Integer(312));
+
+Dict dict = new Dict(new Atom("location"), map);
+```
+
+One can also create a dictionary from its String representation:
+
+```java
+Dict d = (Dict) Term.textToTerm("location{home:loc(12,3), work:loc(32,3), school:loc(3,33)}");
+```
+
+To get the dictionary tag and map:
+
+```java
+public final Term getTag();
+public final Map<Atom, Term> getMap();
+```
 
 ### Java objects  
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -383,10 +383,12 @@
 						<li class="level3 navJavaApiOverview"><div onclick="scrollToId('creating-terms')">Creating terms</div></li>
 						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('atoms')">Atoms</div></li>
 						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('integers')">Integers</div></li>
+						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('rationals')">Rationals</div></li>
 						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('floats')">Floats</div></li>
 						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('variables')">Variables</div></li>
 						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('compound-terms')">Compound terms</div></li>
 						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('lists')">Lists</div></li>
+						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('dictionaries')">Dictionaries</div></li>
 						<li class="level4 navJavaApiOverview"><div onclick="scrollToId('java-objects')">Java objects</div></li>
 
 						<li class="level3 navJavaApiOverview"><div onclick="scrollToId('creating-queries')">Creating queries</div></li>

--- a/src/java/org/jpl7/Dict.java
+++ b/src/java/org/jpl7/Dict.java
@@ -12,7 +12,14 @@ import java.util.stream.Collectors;
  * Dict is a specialised Term representing a Prolog dictionary of the form Tag{Key1:Value1, Key2:Value2, ...}.
  * IN SWIPL refer to https://www.swi-prolog.org/pldoc/man?section=bidicts
  *
+ * <pre>
+ * 	Dict dict1 = new Dict(new Atom("location"), map);
+ * 	Dict t3 = (Dict) Term.textToTerm("location{t:12, z:312, y:23}");
+ * </pre>
+ *
  * <hr>
+ * Copyright (C) 2020 Sebastian Sardina
+ * <p>
  * Copyright (C) 2004 Paul Singleton
  * <p>
  * Copyright (C) 1998 Fred Dushin
@@ -125,7 +132,6 @@ public class Dict extends Term {
 	/**
 	 * whether this Dictionary's functor has 'name' and 'arity' (c.f. traditional functor/3)
 	 *
-	 * TODO: needs to be sync with Prolog
 	 * ?- A = point{x:1, y:2}, A =.. [X|Y].
 	 * A = point{x:1, y:2},
 	 * X = C'dict',
@@ -134,7 +140,7 @@ public class Dict extends Term {
 	 * @return whether this Rational's functor has (long) 'name' and 'arity'
 	 */
 	public final boolean hasFunctor(Term val, int arity) {
-		return this.tag.equals(val) &&  arity == this.map.size();
+		return this.tag.equals("C'dict'") &&  arity == this.map.size() + 1;
 	}
 
 

--- a/src/java/org/jpl7/Dict.java
+++ b/src/java/org/jpl7/Dict.java
@@ -1,0 +1,186 @@
+package org.jpl7;
+
+import org.jpl7.fli.Prolog;
+import org.jpl7.fli.term_t;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Dict is a specialised Term representing a Prolog dictionary of the form Tag{Key1:Value1, Key2:Value2, ...}.
+ * IN SWIPL refer to https://www.swi-prolog.org/pldoc/man?section=bidicts
+ *
+ * <hr>
+ * Copyright (C) 2004 Paul Singleton
+ * <p>
+ * Copyright (C) 1998 Fred Dushin
+ * <p>
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * <ol>
+ * <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ * </ol>
+ *
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * <hr>
+ *
+ * @see Term
+ * @see Compound
+ */
+public class Dict extends Term {
+
+	/**
+	 * The tag of the dictionary - an Atom or a Variable
+	 */
+	protected final Term tag;
+
+	/**
+	 * 	The mapping of the dictionary
+	 */
+	protected final Map<Atom, Term> map;
+
+	/**
+	 * Creates a dictionary structure
+	 *
+	 * @param tag		the tag of the dict as an Atom or Variable
+	 * @param map		a mapping from Atoms to terms
+	 *
+	 */
+	public Dict(Term tag, Map<Atom, Term> map) {
+		this.tag = tag;
+		this.map = map;
+	}
+
+
+	public Dict(String dict) {
+		// We call Prolog to convert a dict as a String into a list of Terms.
+		// Too complex or non-robust (see below) in Java!
+		Term t = new Query(String.format("term_to_atom(_A, '%s'), _A =.. [_| X]", dict)).oneSolution().get("X");
+//		Term t = Term.textToTerm(dict);		// not working, does not yield a list as needed
+		Term[] lt = Term.listToTermArray(t);
+
+		this.tag = (Atom) lt[0];
+		this.map = new HashMap<Atom, Term>();
+		for(int i = 1; i < lt.length-1; i = i + 2) {
+			this.map.put((Atom) lt[i+1], lt[i]);
+		}
+
+		// NOT ROBUST METHOD BECAUSE VALUES CAN BE TERMS WITH COMMAS!
+//		String mapAsText = "";
+//		Pattern p = Pattern.compile("(.+)\\{(.*:.*)\\}");
+//		Matcher m = p.matcher(dict);
+//		if (m.find()) {
+//			this.name = m.group(1);
+//			mapAsText = m.group(2);
+//
+//			try {
+//				this.map = Arrays.stream(mapAsText.split(", "))
+//						.map(entry -> entry.split(":"))
+//						.collect(Collectors.toMap(entry -> new Atom(entry[0]), entry -> Term.textToTerm(entry[1])));
+//			} catch (Exception e) {
+//				throw new  JPLException(String.format("Not a legal dict format (problem with dictionary): %s", dict));
+//			}
+//		}	else {
+//			throw new  JPLException(String.format("Not a legal dict format: %s", dict));
+//		}
+
+	}
+
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Dict dict1 = (Dict) o;
+		return tag.equals(dict1.tag) &&
+				Objects.equals(map, dict1.map);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(tag, map);
+	}
+
+	public final Term getTag() {
+		return tag;
+	};
+	public final Map<Atom, Term> getMap() {
+		return map;
+	};
+
+	/**
+	 * whether this Dictionary's functor has 'name' and 'arity' (c.f. traditional functor/3)
+	 *
+	 * TODO: needs to be sync with Prolog
+	 * ?- A = point{x:1, y:2}, A =.. [X|Y].
+	 * A = point{x:1, y:2},
+	 * X = C'dict',
+	 * Y = [point, 1, x, 2, y].
+	 *
+	 * @return whether this Rational's functor has (long) 'name' and 'arity'
+	 */
+	public final boolean hasFunctor(Term val, int arity) {
+		return this.tag.equals(val) &&  arity == this.map.size();
+	}
+
+
+
+
+	/**
+	 * To convert an Rational into a Prolog term, we put its value into the term_t.
+	 *
+	 * @param varnames_to_vars
+	 *            A Map from variable names to Prolog variables.
+	 * @param term
+	 *            A (previously created) term_t which is to be set to a Prolog integer
+	 */
+	protected final void put(Map<String, term_t> varnames_to_vars, term_t term) {
+		Prolog.put_rational(term, this.toString());	// works well because it is purely syntactic
+	}
+
+	/**
+	 * a Prolog source text representation of this dictionary's value
+	 *
+	 * @return a Prolog source text representation of this dictionary's value
+	 */
+	public String toString() {
+		// https://www.baeldung.com/java-map-to-string-conversion
+		String mapAsString = map.keySet().stream()
+				.map(key -> key + ":" + map.get(key))
+				.collect(Collectors.joining(", ", "{", "}"));
+		return String.format("%s%s", tag.toString(), mapAsString);
+	}
+
+	/**
+	 * the type of this term, as "Prolog.DICT"
+	 *
+	 * @return the type of this term, as "Prolog.DICT"
+	 */
+	public final int type() {
+		return Prolog.DICT;
+	}
+
+	/**
+	 * the name of the type of this term, as "Rational"
+	 *
+	 * @return the name of the type of this term, as "Rational"
+	 */
+	public String typeName() {
+		return "Dict";
+	}
+
+}

--- a/src/java/org/jpl7/Rational.java
+++ b/src/java/org/jpl7/Rational.java
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
  * Rational is a specialised Term representing a Prolog rational value.
  *
  * <pre>
- * Rational i1 = new Rational(2,3);
- * Rational i2 = new Rational(2r3);
+ * Rational r1 = new Rational(2,3);
+ * Rational r2 = new Rational(2r3);
  * </pre>
  *
  * A rational will be stored in its canonical form with gcd(numerator, denominator =  1 (not reducible) and

--- a/src/java/org/jpl7/test/JPLTestSuite.java
+++ b/src/java/org/jpl7/test/JPLTestSuite.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite;
         Test_Variables.class,
         Tests.class,
         Test_Equals.class,
+        Test_Dict.class,
 })
 
 public class JPLTestSuite {

--- a/src/java/org/jpl7/test/junit/Test_Dict.java
+++ b/src/java/org/jpl7/test/junit/Test_Dict.java
@@ -74,8 +74,11 @@ public class Test_Dict extends JPLTest {
     @Test
     public void test_dict2() {
         Term t = Term.textToTerm("location{x:12, z:312, y:23}");
-
         assertEquals(Prolog.DICT, t.type());
+
+        Dict d = (Dict) Term.textToTerm("location{x:12, z:312, y:23}");
+        assertEquals(Prolog.DICT, d.type());
+
     }
 
 
@@ -108,6 +111,21 @@ public class Test_Dict extends JPLTest {
         assertEquals("W{x:12, z:312, y:23}", dict.toString());
         assertEquals(Prolog.DICT, dict.type());
 
+    }
+
+
+
+
+
+    @Test
+    public void test_dict5() {
+        Term t = new Query("current_prolog_flag(abi_version, X)").oneSolution().get("X");
+
+        assertEquals(Prolog.DICT, t.type());
+
+        Dict d = (Dict) t;
+
+        assertEquals(new Atom("abi"), d.getTag());
     }
 
 }

--- a/src/java/org/jpl7/test/junit/Test_Dict.java
+++ b/src/java/org/jpl7/test/junit/Test_Dict.java
@@ -1,0 +1,113 @@
+package org.jpl7.test.junit;
+
+import org.jpl7.*;
+import org.jpl7.Integer;
+import org.jpl7.fli.Prolog;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class Test_Dict extends JPLTest {
+
+    public static void main(String argv[]) {
+        // To be able to call it from CLI without IDE (e.g., by CMAKE)
+        org.junit.runner.JUnitCore.main("org.jpl7.test.junit.Test_Dict");
+
+        // should work from static class but gives error
+//        org.junit.runner.JUnitCore.main( GetSolution.class.getName()); // full name with package
+    }
+
+    /**
+     * This is done at the class loading, before any test is run
+     */
+    @BeforeClass
+    public static void setUp() {
+        setUpClass();
+    }
+
+
+    @Rule
+    public TestRule watcher = new TestWatcher() {
+        protected void starting(Description description) {
+            reportTest(description);
+        }
+    };
+
+
+
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // SUPPORTING CODE
+    ///////////////////////////////////////////////////////////////////////////////
+
+
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // TESTS
+    ///////////////////////////////////////////////////////////////////////////////
+
+
+
+    @Test
+    public void test_dict1() {
+        Map<Atom, Term> map = new HashMap<Atom, Term>();
+
+        map.put(new Atom("x"), new org.jpl7.Integer(12));
+        map.put(new Atom("y"), new org.jpl7.Integer(23));
+        map.put(new Atom("z"), new Integer(312));
+
+        Dict dict = new Dict(new Atom("location"), map);
+
+        assertEquals("location{x:12, z:312, y:23}", dict.toString());
+        assertEquals(Prolog.DICT, dict.type());
+
+    }
+
+    @Test
+    public void test_dict2() {
+        Term t = Term.textToTerm("location{x:12, z:312, y:23}");
+
+        assertEquals(Prolog.DICT, t.type());
+    }
+
+
+    @Test
+    public void test_dict3() {
+        Term t = new Query("X = location{x:there(12,2), z:here(312,2), y:23}").oneSolution().get("X");
+
+        Term t2 = Term.textToTerm("location{x:there(12,2), z:here(312,2), y:23}");
+        Term t3 = Term.textToTerm("location{t:12, z:312, y:23}");
+
+        assertEquals(Prolog.DICT, t.type());
+
+        assertEquals(t2, t);
+        assertNotEquals(t3, t);
+
+    }
+
+
+
+    @Test
+    public void test_dict4() {
+        Map<Atom, Term> map = new HashMap<Atom, Term>();
+
+        map.put(new Atom("x"), new org.jpl7.Integer(12));
+        map.put(new Atom("y"), new org.jpl7.Integer(23));
+        map.put(new Atom("z"), new Integer(312));
+
+        Dict dict = new Dict(new Variable("W"), map);
+
+        assertEquals("W{x:12, z:312, y:23}", dict.toString());
+        assertEquals(Prolog.DICT, dict.type());
+
+    }
+
+}

--- a/src/java/org/jpl7/test/junit/Test_Report.java
+++ b/src/java/org/jpl7/test/junit/Test_Report.java
@@ -41,10 +41,10 @@ public class Test_Report extends JPLTest {
 
 
 
-//    @Test
+    @Test
     public void ReportPrologFlags() {
         StringBuffer sb = new StringBuffer();
-        Query q = new Query("current_prolog_flag(X, Y)");
+            Query q = new Query("current_prolog_flag(X, Y)");
         q.open();
         while (q.hasMoreSolutions()) {
             Map<String,Term> sol = q.nextSolution();


### PR DESCRIPTION
Extended JPL to support [dictionaries](https://www.swi-prolog.org/pldoc/man?section=bidicts)

Having dictionaries is easy via the Java  `Map` which is quite useful and commonly used in Java.

The reason was that in the newest versions of SWIPL, calls with `current_prolog_flag/2` will crash because one of the options now yields a dictionary:

```
?- current_prolog_flag(abi_version, Y).
Y = abi{built_in:2033063160, foreign_interface:2, qlf:67, qlf_min_load:67, record:3, vmi:3726870942}.
```

Fixes #54.
