### PR TITLE
Correct Tutorials link to /Tutorial

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -412,7 +412,7 @@
 -->
 						<li class="level2"><a href="javadoc/index.html" target="_blank" title="Java API - JavaDoc (opens in new window or tab)">JavaDoc</a></li>
 
-						<li class="level1"><a href="Tutorials">Tutorials</a></li>
+						<li class="level1"><a href="Tutorial">Tutorials</a></li>
 						<li class="level2"><a href="TutorialResources">Resources & environment variables</a></li>
 						<li class="level2"><a href="TutorialInitializing">Initializing Prolog engine</a></li>
 						<li class="level2"><a href="TutorialJavaCallsProlog">Java calls Prolog</a></li>


### PR DESCRIPTION
Currently, the point *Tutorials* in the menu links to `/Tutorial`, though the file is called singular `Tutorial` (similar to the others, e.g., `TutorialResources`).