### PR TITLE
Correct class checks in equals methods

### DIFF
--- a/src/main/java/org/jpl7/Atom.java
+++ b/src/main/java/org/jpl7/Atom.java
@@ -115,7 +115,7 @@ public class Atom extends Term {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (o == null || !(o instanceof Atom)) return false;
 		Atom atom = (Atom) o;
 		return name.equals(atom.name) &&
 				type.equals(atom.type);

--- a/src/main/java/org/jpl7/Compound.java
+++ b/src/main/java/org/jpl7/Compound.java
@@ -168,7 +168,7 @@ public class Compound extends Term {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (o == null || !(o instanceof Compound)) return false;
 		Compound compound = (Compound) o;
 		return Arrays.equals(args, compound.args) &&
 				name.equals(compound.name);

--- a/src/main/java/org/jpl7/Dict.java
+++ b/src/main/java/org/jpl7/Dict.java
@@ -112,7 +112,7 @@ public class Dict extends Term {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (o == null || !(o instanceof Dict)) return false;
 		Dict dict1 = (Dict) o;
 		return tag.equals(dict1.tag) &&
 				Objects.equals(map, dict1.map);

--- a/src/main/java/org/jpl7/Integer.java
+++ b/src/main/java/org/jpl7/Integer.java
@@ -130,7 +130,7 @@ public class Integer extends Term {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (o == null || !(o instanceof Integer)) return false;
 		Integer that = (Integer) o;
 		if (this.bigValue == null && that.bigValue == null) { // both are long
 			return this.value == that.value;

--- a/src/main/java/org/jpl7/JRef.java
+++ b/src/main/java/org/jpl7/JRef.java
@@ -76,7 +76,7 @@ public class JRef extends Term {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (o == null || !(o instanceof JRef)) return false;
 		JRef jRef = (JRef) o;
 		return object == jRef.object;
 	}

--- a/src/main/java/org/jpl7/Query.java
+++ b/src/main/java/org/jpl7/Query.java
@@ -562,7 +562,7 @@ public class Query implements Iterable<Map<String, Term>>, Iterator<Map<String, 
 			Term BindingVarTerm = args[args.length - 1]; // the Query's last arg: a variable binding list; type Variable
 			String BindingVarName = ((Variable) BindingVarTerm).name; // its textual name ("Bindings" in example)
 
-			Term TermVar = args[args.length - 2]; // the Query's last arg: a variable binding list; type Variable
+//			Term TermVar = args[args.length - 2]; // the Query's last arg: a variable binding list; type Variable
 //			String TermVarName = ((Variable) TermVar).name; // its textual name ("Bindings" in example)
 
 			// SECOND, we store what B was bound to as JPL Compound list instance BindingVarValue

--- a/src/main/java/org/jpl7/Rational.java
+++ b/src/main/java/org/jpl7/Rational.java
@@ -154,7 +154,7 @@ public class Rational extends Term {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (o == null || !(o instanceof Rational)) return false;
 		Rational rational = (Rational) o;
 		return numerator == rational.numerator &&
 				denominator == rational.denominator;

--- a/src/main/java/org/jpl7/Variable.java
+++ b/src/main/java/org/jpl7/Variable.java
@@ -118,7 +118,7 @@ public class Variable extends Term {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o == null || getClass() != o.getClass() || this.name.equals("_") || ((Variable) o).name.equals("_")) return false;
+		if (o == null || !(o instanceof Variable) || this.name.equals("_") || ((Variable) o).name.equals("_")) return false;
 		if (this == o) return true;
 		Variable variable = (Variable) o;
 		return name.equals(variable.name);

--- a/src/main/java/org/jpl7/fli/LongHolder.java
+++ b/src/main/java/org/jpl7/fli/LongHolder.java
@@ -43,7 +43,7 @@ public class LongHolder {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (o == null || !(o instanceof LongHolder)) return false;
 		LongHolder that = (LongHolder) o;
 		return value == that.value;
 	}


### PR DESCRIPTION
Fix the class comparison in all Java equals() methods in order to allow working inheritance.

Also commented out 1 line that gave a warning about being unused.

Tested working (this resolves some issues with how GOAL uses JPL).