### PR TITLE
Suppress finalize() deprecation/removal warnings in atom_t.java

### DIFF
--- a/src/main/java/org/jpl7/fli/atom_t.java
+++ b/src/main/java/org/jpl7/fli/atom_t.java
@@ -46,6 +46,7 @@ public class atom_t extends LongHolder {
 		return Prolog.atom_chars(this);
 	}
 
+	@SuppressWarnings({"deprecation","removal"})
 	protected void finalize() throws Throwable {
 		super.finalize();
 		Prolog.unregister_atom(this);


### PR DESCRIPTION
suppress deprecation/removal warnings with JDK18+