### PR TITLE
modify cmake ilink calls to not include CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(JNI_FOUND AND Java_FOUND)
 
     if(JNIDIR)
         install(DIRECTORY DESTINATION ${JNIDIR})
-        ilink(${CMAKE_INSTALL_PREFIX}/${SWIPL_INSTALL_ARCH_LIB}/${jpl_module}${JPLEXT}
+        ilink(/${SWIPL_INSTALL_ARCH_LIB}/${jpl_module}${JPLEXT}
               ${JNIDIR}/${jpl_module}${JPLEXT})
     endif()
 


### PR DESCRIPTION
See SWI-Prolog/swipl-devel#1309