### PR TITLE
Fix MSVC C4996 warnings by moving _CRT_SECURE_NO_WARNINGS before includes

### DIFF
--- a/src/main/c/jpl.c
+++ b/src/main/c/jpl.c
@@ -72,6 +72,10 @@ refactoring (trivial):
 
 /*=== includes ============================================================ */
 
+#ifdef __WINDOWS__
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+
 /* SWI-Prolog headers: */
 #include <config.h>
 #include <SWI-Stream.h>
@@ -82,7 +86,6 @@ refactoring (trivial):
 /* OS-specific header (SWI-Prolog FLI and Java Invocation API both seem to need
  * this): but not if we use the .NET 2.0 C compiler
  */
-#define _CRT_SECURE_NO_WARNINGS 1
 #include <windows.h>
 #define SIZEOF_WCHAR_T   2
 #define SIZEOF_LONG      4


### PR DESCRIPTION
## Summary

Fix four MSVC C4996 warnings for `strcpy`/`strcat` in `jpl.c`.

### Changes

- Move existing `_CRT_SECURE_NO_WARNINGS` define from after `SWI-Prolog.h` to before all includes
- The define was already present but placed too late — `SWI-Prolog.h` pulls in `string.h` internally, so by that point MSVC had already annotated `strcpy`/`strcat` as deprecated

### Testing

Built and tested with MSVC (Visual Studio 2026) on Windows x64. All four warnings are resolved.